### PR TITLE
Issue #19: add import link to content sub-menu

### DIFF
--- a/feeds.module
+++ b/feeds.module
@@ -298,6 +298,13 @@ function feeds_menu() {
     'access callback' => 'feeds_page_access',
     'file' => 'feeds.pages.inc',
   );
+  $items['admin/content/import'] = array(
+    'title' => 'Import',
+    'page callback' => 'feeds_page',
+    'access callback' => 'feeds_page_access',
+    'file' => 'feeds.pages.inc',
+    'menu_name' => 'management',
+  );
   $items['import/%feeds_importer'] = array(
     'title callback' => 'feeds_importer_title',
     'title arguments' => array(1),

--- a/feeds.module
+++ b/feeds.module
@@ -293,13 +293,13 @@ function feeds_forms() {
 function feeds_menu() {
   $items = array();
   $items['import'] = array(
-    'title' => 'Import',
+    'title' => 'Feeds Import',
     'page callback' => 'feeds_page',
     'access callback' => 'feeds_page_access',
     'file' => 'feeds.pages.inc',
   );
   $items['admin/content/import'] = array(
-    'title' => 'Import',
+    'title' => 'Feeds Import',
     'page callback' => 'feeds_page',
     'access callback' => 'feeds_page_access',
     'file' => 'feeds.pages.inc',


### PR DESCRIPTION
Addresses #19 

@BWPanda want to take a look? This was the easiest approach. It adds a link in the right place but also leaves the old path available as well.