### PR TITLE
User Import

### DIFF
--- a/plugins/FeedsUserProcessor.inc
+++ b/plugins/FeedsUserProcessor.inc
@@ -622,7 +622,7 @@ class FeedsUserProcessor extends FeedsProcessor {
           // This role may *not* be assigned.
           continue;
         }
-        $entity->roles[$role->name] = $role->label;
+        $entity->roles[$role->name] = $role->name;
       }
     }
   }


### PR DESCRIPTION
I have been using the user import and found out that the role is being set in the database with the role label instead of the machine name. I looked at the code and in the FeedUserProcessor.inc file on line 625 and noticed the entity role was being set with role label. I changed that line to set with the role name and the issue was resolved.