### PR TITLE
Issue #100 - Fix parameter in function feeds_batch

### DIFF
--- a/feeds.module
+++ b/feeds.module
@@ -289,13 +289,13 @@ function feeds_push_unsubscribe($job) {
  *   Identifier of a FeedsImporter object.
  * @param int $feed_nid
  *   If importer is attached to content type, feed node id identifying the
- *   source to be imported.
+ *   source to be imported. Set to zero if not attached to a node.
  * @param array $context
  *   Batch context.
  *
  * @see FeedsSource::startBatchAPIJob()
  */
-function feeds_batch($method, $importer_id, &$context, $feed_nid = 0) {
+function feeds_batch($method, $importer_id, $feed_nid, &$context) {
   $context['finished'] = FEEDS_BATCH_COMPLETE;
   try {
     $context['finished'] = feeds_source($importer_id, $feed_nid)->$method();

--- a/feeds.module
+++ b/feeds.module
@@ -295,7 +295,7 @@ function feeds_push_unsubscribe($job) {
  *
  * @see FeedsSource::startBatchAPIJob()
  */
-function feeds_batch($method, $importer_id, $feed_nid = 0, &$context) {
+function feeds_batch($method, $importer_id, &$context, $feed_nid = 0) {
   $context['finished'] = FEEDS_BATCH_COMPLETE;
   try {
     $context['finished'] = feeds_source($importer_id, $feed_nid)->$method();


### PR DESCRIPTION
Fixes #100 

This re-orders the parameters in the function and clears the error message.
It appears to be called from FeedsSource.inc
https://github.com/backdrop-contrib/feeds/blob/9b4da2b41208ed5bcdc11884b241538e9f8c3c0f/includes/FeedsSource.inc#L1189-L1210

What I'm not sure is how to test that the change made doesn't break this.