### PR TITLE
Issue #111 Added back autocreate for user roles

### DIFF
--- a/plugins/FeedsUserProcessor.inc
+++ b/plugins/FeedsUserProcessor.inc
@@ -555,6 +555,22 @@ class FeedsUserProcessor extends FeedsProcessor {
       }
 
       $role = user_role_load($value);
+      
+      if (!$role && !empty($mapping['autocreate'])) {
+        $role = new stdClass();
+        $role->name = $value;
+        // Create an arbitrary label based on the machine name.
+        // But if the machine name is an int (a Drupal 7 Role ID), then
+        // provide a default label.
+        if (!is_numeric($value)) {
+          $role->label = ucfirst(strtr($value, array('_' => ' ')));
+        } 
+        else {
+          $role->label = 'Role ' . $value;
+        }
+        user_role_save($role);
+        $role = user_role_load($role->label);
+      }
 
       if ($role) {
         // Check if the role may be assigned.


### PR DESCRIPTION
Fixes #117 and #111 

Added back user role autocreate functionality.
- If the role name is non-numeric, the label is created based on the role machine name by capitalizing the first letter and converting _ to space
- If the role is numeric (e.g. because this is an export of role ID from a D7 site), the default "Role N" is created, where N is the D7 role ID