### PR TITLE
Issue #124: Add missing dependency to workflow

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -34,6 +34,12 @@ jobs:
         with:
           repository: backdrop/backdrop
 
+      - name: Checkout dependency
+        uses: actions/checkout@v2
+        with:
+          repository: backdrop-contrib/job_scheduler
+          path: modules/job_scheduler
+
       - name: Checkout module
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Fixes #124 (again), sorry I forgot to add the job_scheduler dependency to the workflow install.