### PR TITLE
Issue #127: More basic test fixes

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -34,11 +34,17 @@ jobs:
         with:
           repository: backdrop/backdrop
 
-      - name: Checkout dependency
+      - name: Checkout dependency job_scheduler
         uses: actions/checkout@v2
         with:
           repository: backdrop-contrib/job_scheduler
           path: modules/job_scheduler
+
+      - name: Checkout test dependency feeds_xpathparser
+        uses: actions/checkout@v2
+        with:
+          repository: backdrop-contrib/feeds_xpathparser
+          path: modules/feeds_xpathparser
 
       - name: Checkout module
         uses: actions/checkout@v2
@@ -62,4 +68,4 @@ jobs:
           core/scripts/install.sh --db-url=mysql://root:root@127.0.0.1/backdrop
 
       - name: Run functional tests
-        run: core/scripts/run-tests.sh --force --directory=modules/${{ env.REPO_NAME }} --verbose --color --concurrency=5 --cache 2>&1
+        run: core/scripts/run-tests.sh --force --directory=modules/${{ env.REPO_NAME }} --verbose --color --concurrency=4 --cache 2>&1

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -62,4 +62,4 @@ jobs:
           core/scripts/install.sh --db-url=mysql://root:root@127.0.0.1/backdrop
 
       - name: Run functional tests
-        run: core/scripts/run-tests.sh --force --directory=modules/${{ env.REPO_NAME }} --verbose --color --concurrency=3 --cache 2>&1
+        run: core/scripts/run-tests.sh --force --directory=modules/${{ env.REPO_NAME }} --verbose --color --concurrency=5 --cache 2>&1

--- a/tests/FeedsAccountSwitcherTest.test
+++ b/tests/FeedsAccountSwitcherTest.test
@@ -5,6 +5,8 @@
  * Contains FeedsAccountSwitcherTest.
  */
 
+include_once __DIR__ . '/feeds_mapper.test';
+
 /**
  * Test case for account switching.
  */
@@ -34,7 +36,7 @@ class FeedsAccountSwitcherTest extends FeedsMapperTestCase {
       )
     );
 
-    // Clear cache to make permission 'create article content' available.
+    // Clear cache to make permission 'create post content' available.
     backdrop_static_reset();
     backdrop_flush_all_caches();
   }
@@ -67,7 +69,7 @@ class FeedsAccountSwitcherTest extends FeedsMapperTestCase {
     $nid = $this->createFeedNode('syndication', $GLOBALS['base_url'] . '/' . backdrop_get_path('module', 'feeds') . '/tests/feeds/content.csv', 'Node 1');
     $account = $this->backdropCreateUser(array(
       'access content',
-      'create article content',
+      'create post content',
     ));
     $this->changeNodeAuthor($nid, $account);
 
@@ -115,7 +117,7 @@ class FeedsAccountSwitcherTest extends FeedsMapperTestCase {
     $nid = $this->createFeedNode('syndication', $GLOBALS['base_url'] . '/' . backdrop_get_path('module', 'feeds') . '/tests/feeds/content.csv', 'Node 1');
     $account = $this->backdropCreateUser(array(
       'access content',
-      'create article content',
+      'create post content',
     ));
     $this->changeNodeAuthor($nid, $account);
 
@@ -258,7 +260,7 @@ class FeedsAccountSwitcherTest extends FeedsMapperTestCase {
     $nid = $this->createFeedNode('syndication', NULL, 'Node 1');
     $account = $this->backdropCreateUser(array(
       'access content',
-      'create article content',
+      'create post content',
     ));
     $this->changeNodeAuthor($nid, $account);
 

--- a/tests/FeedsEnclosureTest.test
+++ b/tests/FeedsEnclosureTest.test
@@ -4,6 +4,12 @@
  * @coversDefaultClass FeedsEnclosure
  * @group feeds
  */
+
+include_once __DIR__ . '/feeds.test';
+
+/**
+ *
+ */
 class FeedsEnclosureTest extends FeedsWebTestCase {
 
   /**

--- a/tests/FeedsFetcherResultTest.test
+++ b/tests/FeedsFetcherResultTest.test
@@ -1,4 +1,9 @@
 <?php
+/**
+ * @file
+ */
+
+include_once __DIR__ . '/feeds.test';
 
 /**
  * @coversDefaultClass FeedsFetcherResult

--- a/tests/FeedsHTTPCacheTest.test
+++ b/tests/FeedsHTTPCacheTest.test
@@ -1,4 +1,9 @@
 <?php
+/**
+ * @file
+ */
+
+include_once __DIR__ . '/feeds.test';
 
 /**
  * @coversDefaultClass FeedsHTTPCache

--- a/tests/FeedsSourceTest.test
+++ b/tests/FeedsSourceTest.test
@@ -1,4 +1,9 @@
 <?php
+/**
+ * @file
+ */
+
+include_once __DIR__ . '/feeds.test';
 
 /**
  * @coversDefaultClass FeedsSource

--- a/tests/common_syndication_parser.test
+++ b/tests/common_syndication_parser.test
@@ -5,7 +5,7 @@
  * Tests for the common syndication parser.
  */
 
-include_once 'feeds.test';
+include_once __DIR__ . '/feeds.test';
 
 /**
  * Test cases for common syndication parser library.

--- a/tests/feeds/encoding.csv.php
+++ b/tests/feeds/encoding.csv.php
@@ -5,8 +5,6 @@
  * Result of encoding_{code}.csv file parsed by ParserCSV.inc.
  */
 
-include_once 'feeds.test';
-
 // JSON is used here because it supports unicode literals. PHP does not.
 $json = <<<EOT
 [

--- a/tests/feeds/nodes.csv.php
+++ b/tests/feeds/nodes.csv.php
@@ -5,8 +5,6 @@
  * Result of nodes.csv file parsed by ParserCSV.inc.
  */
 
-include_once 'feeds.test';
-
 $control_result = array(
   0 =>
   array(

--- a/tests/feeds_content_type.test
+++ b/tests/feeds_content_type.test
@@ -5,6 +5,8 @@
  * Contains FeedsContentTypeTest.
  */
 
+include_once __DIR__ . '/feeds.test';
+
 /**
  * Tests for when an importer is attached to a content type.
  */

--- a/tests/feeds_content_type.test
+++ b/tests/feeds_content_type.test
@@ -95,12 +95,7 @@ class FeedsContentTypeTest extends FeedsWebTestCase {
    */
   public function testWithContentTypeWithoutTitle() {
     // Set that the content type 'page' has no title.
-    db_update('node_type')
-      ->fields(array(
-        'has_title' => 0,
-      ))
-      ->condition('type', 'page')
-      ->execute();
+    config_set('node.type.page', 'has_title', 0);
 
     // Flush caches so this change is picked up.
     backdrop_flush_all_caches();

--- a/tests/feeds_entity.test
+++ b/tests/feeds_entity.test
@@ -5,6 +5,8 @@
  * Test cases for entity API integration.
  */
 
+include_once __DIR__ . '/feeds.test';
+
 /**
  * Tests for Entity API integration.
  */

--- a/tests/feeds_fetcher_file.test
+++ b/tests/feeds_fetcher_file.test
@@ -5,7 +5,7 @@
  * File fetcher tests.
  */
 
-include_once 'feeds.test';
+include_once __DIR__ . '/feeds.test';
 
 /**
  * File fetcher test class.

--- a/tests/feeds_fetcher_http.test
+++ b/tests/feeds_fetcher_http.test
@@ -5,7 +5,7 @@
  * Contains FeedsFileHTTPTestCase.
  */
 
-include_once 'feeds.test';
+include_once __DIR__ . '/feeds.test';
 
 /**
  * HTTP fetcher test class.

--- a/tests/feeds_hooks.test
+++ b/tests/feeds_hooks.test
@@ -1,9 +1,10 @@
 <?php
-
 /**
  * @file
  * Contains FeedsHooksTestCase.
  */
+
+include_once __DIR__ . '/feeds.test';
 
 /**
  * Tests for hooks invoked by Feeds not related to mapping.
@@ -39,7 +40,7 @@ class FeedsHooksTestCase extends FeedsWebTestCase {
     $this->setPlugin('csv', 'FeedsFileFetcher');
     $this->setPlugin('csv', 'FeedsCSVParser');
     $this->setSettings('csv', 'FeedsNodeProcessor', array(
-      'bundle' => 'article',
+      'bundle' => 'post',
       'update_existing' => FEEDS_UPDATE_EXISTING,
     ));
     $this->addMappings('csv', array(
@@ -50,9 +51,9 @@ class FeedsHooksTestCase extends FeedsWebTestCase {
       ),
     ));
 
-    // Create an article node that gets updated.
+    // Create an post node that gets updated.
     $node = $this->backdropCreateNode(array(
-      'type' => 'article',
+      'type' => 'post',
       'title' => 'Lorem ipsum',
     ));
 

--- a/tests/feeds_i18n.test
+++ b/tests/feeds_i18n.test
@@ -5,8 +5,7 @@
  * Contains Feedsi18nTestCase.
  */
 
-include_once 'feeds.test';
-include_once 'feeds_mapper.test';
+include_once __DIR__ . '/feeds_mapper.test';
 
 /**
  * Tests importing data in a language.

--- a/tests/feeds_i18n.test
+++ b/tests/feeds_i18n.test
@@ -89,7 +89,7 @@ class Feedsi18nTestCase extends FeedsMapperTestCase {
     $this->importFile('i18n', $this->absolutePath() . '/tests/feeds/content.csv');
 
     // Assert that the entity's language is now in Dutch.
-    $entities = entity_load_multiple_multiple($this->entityType, array(1, 2));
+    $entities = entity_load_multiple($this->entityType, array(1, 2));
     foreach ($entities as $entity) {
       $this->assertEqual('nl', $entity->langcode);
     }

--- a/tests/feeds_i18n_node.test
+++ b/tests/feeds_i18n_node.test
@@ -5,8 +5,8 @@
  * Contains Feedsi18nNodeTestCase.
  */
 
-include_once 'feeds.test';
-include_once 'feeds_i18n.test';
+include_once __DIR__ . '/feeds.test';
+include_once __DIR__ . '/feeds_i18n.test';
 
 /**
  * Tests importing nodes in a language.

--- a/tests/feeds_i18n_taxonomy.test
+++ b/tests/feeds_i18n_taxonomy.test
@@ -5,8 +5,8 @@
  * Contains Feedsi18nTaxonomyTestCase.
  */
 
-include_once 'feeds.test';
-include_once 'feeds_i18n.test';
+include_once __DIR__ . '/feeds.test';
+include_once __DIR__ . '/feeds_i18n.test';
 
 /**
  * Tests importing terms in a language.

--- a/tests/feeds_mapper.test
+++ b/tests/feeds_mapper.test
@@ -5,7 +5,7 @@
  * Contains FeedsMapperTestCase.
  */
 
-include_once 'feeds.test';
+include_once __DIR__ . '/feeds.test';
 
 /**
  * Helper class with auxiliary functions for feeds mapper module tests.
@@ -157,9 +157,17 @@ class FeedsMapperTestCase extends FeedsWebTestCase {
       $this->backdropPost($admin_type_url . '/fields', $edit, 'Save');
 
       // Second step is skipped if the field has no settings.
-      // @todo
+      // @todo Is there a smarter way to check that?
       debug($field_type);
-      $has_settings = array('text', 'file', 'image', 'number_decimal');
+      $has_settings = array(
+        'text',
+        'file',
+        'image',
+        'number_decimal',
+        'date',
+        'datestamp',
+        'datetime',
+      );
       if (in_array($field_type, $has_settings)) {
         $edit = isset($options['settings']) ? $options['settings'] : array();
         $this->backdropPost(NULL, $edit, 'Save field settings');

--- a/tests/feeds_mapper_date_multiple.test
+++ b/tests/feeds_mapper_date_multiple.test
@@ -31,7 +31,7 @@ class FeedsMapperDateMultipleTestCase extends FeedsMapperTestCase {
    * {@inheritdoc}
    */
   public function setUp() {
-    parent::setUp(array('date_api', 'date', 'feeds_xpathparser'));
+    parent::setUp(array('date', 'feeds_xpathparser'));
     config_set('feeds.settings', 'date_default_timezone', 'UTC');
   }
 

--- a/tests/feeds_mapper_path.test
+++ b/tests/feeds_mapper_path.test
@@ -163,7 +163,7 @@ class FeedsMapperPathTestCase extends FeedsMapperTestCase {
 }
 
 /**
- * Class for testing Feeds <em>path</em> mapper with pathauto.module.
+ * Class for testing Feeds <em>path</em> mapper with path.module.
  */
 class FeedsMapperPathPathautoTestCase extends FeedsMapperTestCase {
 
@@ -183,7 +183,7 @@ class FeedsMapperPathPathautoTestCase extends FeedsMapperTestCase {
    * {@inheritdoc}
    */
   public function setUp() {
-    parent::setUp(array('pathauto'));
+    parent::setUp(array('path'));
   }
 
   /**

--- a/tests/feeds_mapper_taxonomy.test
+++ b/tests/feeds_mapper_taxonomy.test
@@ -17,6 +17,7 @@ class FeedsMapperTaxonomyTestCase extends FeedsMapperTestCase {
    */
   public function setUp() {
     parent::setUp();
+    module_load_include('inc', 'feeds' , 'plugins/FeedsPlugin');
 
     // Add Tags vocabulary.
     $edit = array(
@@ -220,10 +221,10 @@ class FeedsMapperTaxonomyTestCase extends FeedsMapperTestCase {
     // Create 10 terms. The first one was created in setup.
     $terms = array(1);
     foreach (range(2, 10) as $i) {
-      $term = (object) array(
+      $term = new TaxonomyTerm(array(
         'name' => 'term' . $i,
         'vid' => 1,
-      );
+      ));
       taxonomy_term_save($term);
       $terms[] = $term->tid;
     }

--- a/tests/feeds_mapper_taxonomy.test
+++ b/tests/feeds_mapper_taxonomy.test
@@ -231,7 +231,7 @@ class FeedsMapperTaxonomyTestCase extends FeedsMapperTestCase {
 
     FeedsPlugin::loadMappers();
 
-    $entity = new stdClass();
+    $entity = new Node();
     $target = 'field_tags';
     $mapping = array(
       'term_search' => FEEDS_TAXONOMY_SEARCH_TERM_ID,
@@ -282,7 +282,7 @@ class FeedsMapperTaxonomyTestCase extends FeedsMapperTestCase {
 
     FeedsPlugin::loadMappers();
 
-    $entity = new stdClass();
+    $entity = new Node();
     $target = 'field_tags';
     $mapping = array(
       'term_search' => FEEDS_TAXONOMY_SEARCH_TERM_GUID,
@@ -310,26 +310,26 @@ class FeedsMapperTaxonomyTestCase extends FeedsMapperTestCase {
    */
   public function testAllowedVocabularies() {
     // Create a second vocabulary.
-    $vocabulary = new stdClass();
+    $vocabulary = new TaxonomyTerm();
     $vocabulary->name = 'Foo';
     $vocabulary->machine_name = 'foo';
     taxonomy_vocabulary_save($vocabulary);
 
     // Add a term to this vocabulary.
-    $term1 = new stdClass();
+    $term1 = new TaxonomyTerm();
     $term1->name = 'Foo1';
     $term1->vid = $vocabulary->vid;
     taxonomy_term_save($term1);
 
     // Add a term to the tags vocabulary.
-    $term2 = new stdClass();
+    $term2 = new TaxonomyTerm();
     $term2->name = 'Bar1';
     $term2->vid = 1;
     taxonomy_term_save($term2);
 
     FeedsPlugin::loadMappers();
 
-    $entity = new stdClass();
+    $entity = new Node();
     $target = 'field_tags';
     $terms = array(
       'Foo1',
@@ -494,11 +494,11 @@ class FeedsMapperTaxonomyTestCase extends FeedsMapperTestCase {
     ));
 
     // Create a few terms used in developmentseed.rss2.
-    $term1 = new stdClass();
+    $term1 = new TaxonomyTerm();
     $term1->name = 'Backdrop';
     $term1->vid = 1;
     taxonomy_term_save($term1);
-    $term2 = new stdClass();
+    $term2 = new TaxonomyTerm();
     $term2->name = 'translation';
     $term2->vid = 1;
     taxonomy_term_save($term2);

--- a/tests/feeds_mapper_taxonomy.test
+++ b/tests/feeds_mapper_taxonomy.test
@@ -255,10 +255,10 @@ class FeedsMapperTaxonomyTestCase extends FeedsMapperTestCase {
     // Create 10 terms. The first one was created in setup.
     $tids = array(1);
     foreach (range(2, 10) as $i) {
-      $term = (object) array(
+      $term = new TaxonomyTerm(array(
         'name' => 'term' . $i,
         'vid' => 1,
-      );
+      ));
       taxonomy_term_save($term);
       $tids[] = $term->tid;
     }

--- a/tests/feeds_og.test
+++ b/tests/feeds_og.test
@@ -5,6 +5,8 @@
  * Contains FeedsOgTest.
  */
 
+include_once __DIR__ . '/feeds.test';
+
 /**
  * Tests for Organic Groups integration.
  */
@@ -31,10 +33,10 @@ class FeedsOgTest extends FeedsWebTestCase {
     // Add OG group field to the node type 'page'.
     og_create_field(OG_GROUP_FIELD, 'node', 'page');
 
-    // Add OG audience field to the node's "article" bundle.
+    // Add OG audience field to the node's "post" bundle.
     $og_field = og_fields_info(OG_AUDIENCE_FIELD);
     $og_field['field']['settings']['target_type'] = 'node';
-    og_create_field(OG_AUDIENCE_FIELD, 'node', 'article', $og_field);
+    og_create_field(OG_AUDIENCE_FIELD, 'node', 'post', $og_field);
 
     // Do not use curl as that will result into HTTP requests returning a 404.
     variable_set('feeds_never_use_curl', TRUE);
@@ -55,7 +57,7 @@ class FeedsOgTest extends FeedsWebTestCase {
       )
     );
 
-    // Clear cache to make permission 'create article content' available.
+    // Clear cache to make permission 'create post content' available.
     backdrop_static_reset();
     backdrop_flush_all_caches();
   }
@@ -121,7 +123,7 @@ class FeedsOgTest extends FeedsWebTestCase {
     $nid = $this->createFeedNode('syndication', $GLOBALS['base_url'] . '/' . backdrop_get_path('module', 'feeds') . '/tests/feeds/content.csv', 'Node 1');
     $account = $this->backdropCreateUser(array(
       'access content',
-      'create article content',
+      'create post content',
     ));
     $this->changeNodeAuthor($nid, $account);
 
@@ -199,7 +201,7 @@ class FeedsOgTest extends FeedsWebTestCase {
     // Create a role with permission to create content.
     $role_name = $this->backdropCreateRole(array(
       'access content',
-      'create article content',
+      'create post content',
     ));
 
     // Create two accounts.
@@ -230,7 +232,7 @@ class FeedsOgTest extends FeedsWebTestCase {
     $nid = $this->createFeedNode('syndication', $GLOBALS['base_url'] . '/' . backdrop_get_path('module', 'feeds') . '/tests/feeds/content_author.csv', 'Node 1');
     $account = $this->backdropCreateUser(array(
       'access content',
-      'create article content',
+      'create post content',
     ));
     $this->changeNodeAuthor($nid, $account);
 

--- a/tests/feeds_parser_csv.test
+++ b/tests/feeds_parser_csv.test
@@ -5,7 +5,7 @@
  * Contains FeedsCSVParserTestCase.
  */
 
-include_once 'feeds.test';
+include_once __DIR__ . '/feeds.test';
 
 /**
  * Tests the CSV parser using the UI.

--- a/tests/feeds_parser_sitemap.test
+++ b/tests/feeds_parser_sitemap.test
@@ -5,7 +5,7 @@
  * Tests for plugins/FeedsSitemapParser.inc.
  */
 
-include_once 'feeds.test';
+include_once __DIR__ . '/feeds.test';
 
 /**
  * Test Sitemap parser.

--- a/tests/feeds_parser_syndication.test
+++ b/tests/feeds_parser_syndication.test
@@ -5,7 +5,7 @@
  * Tests for plugins/FeedsSyndicationParser.inc.
  */
 
-include_once 'feeds.test';
+include_once __DIR__ . '/feeds.test';
 
 /**
  * Test single feeds.

--- a/tests/feeds_parser_syndication.test
+++ b/tests/feeds_parser_syndication.test
@@ -5,7 +5,7 @@
  * Tests for plugins/FeedsSyndicationParser.inc.
  */
 
-include_once __DIR__ . '/feeds.test';
+include_once __DIR__ . '/feeds_mapper.test';
 
 /**
  * Test single feeds.

--- a/tests/feeds_processor_node.test
+++ b/tests/feeds_processor_node.test
@@ -5,7 +5,7 @@
  * Tests for plugins/FeedsNodeProcessor.inc.
  */
 
-include_once 'feeds.test';
+include_once __DIR__ . '/feeds.test';
 
 /**
  * Test aggregating a feed as node items.
@@ -35,7 +35,7 @@ class FeedsRSStoNodesTest extends FeedsWebTestCase {
     // Set the teaser length display to unlimited otherwise tests looking for
     // text on nodes will fail.
     $edit = array('fields[body][type]' => 'text_default');
-    $this->backdropPost('admin/structure/types/manage/article/display/teaser', $edit, 'Save');
+    $this->backdropPost('admin/structure/types/manage/post/display/teaser', $edit, 'Save');
 
     // Create an importer configuration.
     $this->createImporterConfiguration('Syndication', 'syndication');
@@ -76,8 +76,8 @@ class FeedsRSStoNodesTest extends FeedsWebTestCase {
 
     // Assert 10 items aggregated after creation of the node.
     $this->assertText('Created 10 nodes');
-    $article_nid = db_query_range("SELECT nid FROM {node} WHERE type = 'article'", 0, 1)->fetchField();
-    $this->assertEqual("Created by FeedsNodeProcessor", db_query("SELECT nr.log FROM {node} n JOIN {node_revision} nr ON n.vid = nr.vid WHERE n.nid = :nid", array(':nid' => $article_nid))->fetchField());
+    $post_nid = db_query_range("SELECT nid FROM {node} WHERE type = 'post'", 0, 1)->fetchField();
+    $this->assertEqual("Created by FeedsNodeProcessor", db_query("SELECT nr.log FROM {node} n JOIN {node_revision} nr ON n.vid = nr.vid WHERE n.nid = :nid", array(':nid' => $post_nid))->fetchField());
 
     // Navigate to feed node, there should be Feeds tabs visible.
     $this->backdropGet("node/$nid");
@@ -114,7 +114,7 @@ class FeedsRSStoNodesTest extends FeedsWebTestCase {
     $edit = array(
       'node_options[status]' => FALSE,
     );
-    $this->backdropPost('admin/structure/types/manage/article', $edit, t('Save content type'));
+    $this->backdropPost('admin/structure/types/manage/post', $edit, t('Save content type'));
     $this->backdropPost("node/$nid/delete-items", array(), 'Delete');
     $this->backdropPost("node/$nid/import", array(), 'Import');
     $count = db_query("SELECT COUNT(*) FROM {node} n INNER JOIN {feeds_item} fi ON fi.entity_type = 'node' AND n.nid = fi.entity_id WHERE n.status = 0")->fetchField();
@@ -122,7 +122,7 @@ class FeedsRSStoNodesTest extends FeedsWebTestCase {
     $edit = array(
       'node_options[status]' => TRUE,
     );
-    $this->backdropPost('admin/structure/types/manage/article', $edit, t('Save content type'));
+    $this->backdropPost('admin/structure/types/manage/post', $edit, t('Save content type'));
     $this->backdropPost("node/$nid/delete-items", array(), 'Delete');
 
     // Enable replace existing and import updated feed file.
@@ -443,14 +443,14 @@ class FeedsRSStoNodesTest extends FeedsWebTestCase {
    * Test that feed elements and links are not found on non-feed nodes.
    */
   public function testNonFeedNodeUI() {
-    // There should not be feed links on an article node.
-    $non_feed_node = $this->backdropCreateNode(array('type' => 'article'));
+    // There should not be feed links on an post node.
+    $non_feed_node = $this->backdropCreateNode(array('type' => 'post'));
     $this->backdropGet('node/' . $non_feed_node->nid);
     $this->assertNoLinkByHref('node/' . $non_feed_node->nid . '/import');
     $this->assertNoLink('Delete items');
 
     // Navigate to a non-feed node form, there should be no Feed field visible.
-    $this->backdropGet('node/add/article');
+    $this->backdropGet('node/add/post');
     $this->assertNoFieldByName('feeds[FeedsHTTPFetcher][source]');
   }
 
@@ -484,7 +484,7 @@ class FeedsRSStoNodesTest extends FeedsWebTestCase {
     $nid = $this->createFeedNode();
 
     $this->assertText('Failed importing 10 nodes.');
-    $this->assertText('The user ' . $account->name . ' is not authorized to create content of type article.');
+    $this->assertText('The user ' . $account->name . ' is not authorized to create content of type post.');
     $node_count = db_query("SELECT COUNT(*) FROM {node}")->fetchField();
 
     // We should have 1 node, the feed node.
@@ -751,11 +751,11 @@ class FeedsRSStoNodesTest extends FeedsWebTestCase {
     // Now create two nodes with titles that are present in the source
     // "developmentseed.rss2".
     $this->backdropCreateNode(array(
-      'type' => 'article',
+      'type' => 'post',
       'title' => 'Open Atrium Translation Workflow: Two Way Translation Updates',
     ));
     $this->backdropCreateNode(array(
-      'type' => 'article',
+      'type' => 'post',
       'title' => 'Week in DC Tech: October 5th Edition',
     ));
 
@@ -796,10 +796,10 @@ class FeedsRSStoNodesTest extends FeedsWebTestCase {
     backdrop_static_reset();
     node_types_rebuild();
 
-    // Create a role with permission to create articles.
+    // Create a role with permission to create posts.
     $role_name = $this->backdropCreateRole(array(
       'access content',
-      'create article content',
+      'create post content',
     ));
 
     // Create account with uid 201.

--- a/tests/feeds_processor_term.test
+++ b/tests/feeds_processor_term.test
@@ -5,7 +5,7 @@
  * Tests for plugins/FeedsTermProcessor.inc.
  */
 
-include_once 'feeds.test';
+include_once __DIR__ . '/feeds.test';
 
 /**
  * Test aggregating a feed as data records.

--- a/tests/feeds_processor_user.test
+++ b/tests/feeds_processor_user.test
@@ -5,7 +5,7 @@
  * Tests for plugins/FeedsUserProcessor.inc.
  */
 
-include_once 'feeds.test';
+include_once __DIR__ . '/feeds.test';
 
 /**
  * Test aggregating a feed as data records.

--- a/tests/feeds_push.test
+++ b/tests/feeds_push.test
@@ -6,6 +6,7 @@
  */
 
 include_once __DIR__ . '/feeds.test';
+include_once __DIR__ . '/../libraries/PuSHSubscriber.inc';
 
 /**
  * Tests for PubSubHubbub support in feeds.

--- a/tests/feeds_push.test
+++ b/tests/feeds_push.test
@@ -5,7 +5,7 @@
  * Contains FeedsPushTest.
  */
 
-include_once 'feeds.test';
+include_once __DIR__ . '/feeds.test';
 
 /**
  * Tests for PubSubHubbub support in feeds.

--- a/tests/feeds_rules.test
+++ b/tests/feeds_rules.test
@@ -5,6 +5,8 @@
  * Contains FeedsRulesTest.
  */
 
+include_once __DIR__ . '/feeds.test';
+
 /**
  * Tests for Rules integration.
  */

--- a/tests/feeds_scheduler.test
+++ b/tests/feeds_scheduler.test
@@ -5,7 +5,7 @@
  * Feeds tests.
  */
 
-include_once 'feeds.test';
+include_once __DIR__ . '/feeds.test';
 
 /**
  * Test cron scheduling.
@@ -40,9 +40,9 @@ class FeedsSchedulerTestCase extends FeedsWebTestCase {
     $this->cronRun();
     $this->cronRun();
 
-    // There should be 0 article nodes in the database.
-    $count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'article' AND status = 1")->fetchField();
-    $this->assertEqual($count, 0, 'There are 0 article nodes aggregated.');
+    // There should be 0 post nodes in the database.
+    $count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'post' AND status = 1")->fetchField();
+    $this->assertEqual($count, 0, 'There are 0 post nodes aggregated.');
   }
 
   /**
@@ -67,9 +67,9 @@ class FeedsSchedulerTestCase extends FeedsWebTestCase {
       '@actual' => count($schedule),
     )));
 
-    // There should be 200 article nodes in the database.
-    $count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'article' AND status = 1")->fetchField();
-    $this->assertEqual($count, 200, format_string('There are 200 article nodes aggregated (actual: @actual).', array(
+    // There should be 200 post nodes in the database.
+    $count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'post' AND status = 1")->fetchField();
+    $this->assertEqual($count, 200, format_string('There are 200 post nodes aggregated (actual: @actual).', array(
       '@actual' => $count,
     )));
 
@@ -123,9 +123,9 @@ class FeedsSchedulerTestCase extends FeedsWebTestCase {
     }
     $this->assertFalse($equal, 'Every feed schedule time changed.');
 
-    // There should be 200 article nodes in the database.
-    $count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'article' AND status = 1")->fetchField();
-    $this->assertEqual($count, 200, 'The total of 200 article nodes has not changed.');
+    // There should be 200 post nodes in the database.
+    $count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'post' AND status = 1")->fetchField();
+    $this->assertEqual($count, 200, 'The total of 200 post nodes has not changed.');
 
     // Set expire settings, check rescheduling.
     $max_last = db_query("SELECT MAX(last) FROM {job_schedule} WHERE type = 'syndication' AND name = 'feeds_source_import' AND period = 0")->fetchField();
@@ -197,8 +197,8 @@ class FeedsSchedulerTestCase extends FeedsWebTestCase {
     $this->cronRun();
 
     // Assert that no nodes were created yet.
-    $count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'article'")->fetchField();
-    $this->assertEqual(0, $count, format_string('There are no articles yet (actual: @count).', array(
+    $count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'post'")->fetchField();
+    $this->assertEqual(0, $count, format_string('There are no posts yet (actual: @count).', array(
       '@count' => $count,
     )));
 
@@ -208,9 +208,9 @@ class FeedsSchedulerTestCase extends FeedsWebTestCase {
     // And run cron again.
     $this->cronRun();
 
-    // Assert that 10 articles were created.
-    $count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'article'")->fetchField();
-    $this->assertEqual(10, $count, format_string('10 articles have been created (actual: @count).', array(
+    // Assert that 10 posts were created.
+    $count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'post'")->fetchField();
+    $this->assertEqual(10, $count, format_string('10 posts have been created (actual: @count).', array(
       '@count' => $count,
     )));
   }
@@ -351,7 +351,7 @@ class FeedsSchedulerTestCase extends FeedsWebTestCase {
 
       db_query("UPDATE {job_schedule} SET next = 0");
       $this->backdropPost('import/node/delete-items', array(), 'Delete');
-      $node_count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'article'")->fetchField();
+      $node_count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'post'")->fetchField();
       $this->assertEqual(0, $node_count);
 
       // Hit cron for importing, until we have all items or when we are running
@@ -360,12 +360,12 @@ class FeedsSchedulerTestCase extends FeedsWebTestCase {
       $ran = 0;
       while ($node_count < 86 && $ran < $max_runs) {
         $this->cronRun();
-        $node_count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'article'")->fetchField();
+        $node_count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'post'")->fetchField();
         $ran++;
       }
 
       // Assert that 86 nodes exist now.
-      $node_count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'article'")->fetchField();
+      $node_count = db_query("SELECT COUNT(*) FROM {node} WHERE type = 'post'")->fetchField();
       $this->assertEqual(86, $node_count, format_string('86 nodes exist after batched importing via cron (actual: @actual).', array(
         '@actual' => $node_count,
       )));
@@ -376,13 +376,13 @@ class FeedsSchedulerTestCase extends FeedsWebTestCase {
 
     // Delete a couple of nodes, then hit cron again. They should not be
     // replaced as the minimum update time is 30 minutes.
-    $nodes = db_query_range("SELECT nid FROM {node} WHERE type = 'article'", 0, 2);
+    $nodes = db_query_range("SELECT nid FROM {node} WHERE type = 'post'", 0, 2);
     foreach ($nodes as $node) {
       $this->backdropPost("node/{$node->nid}/delete", array(), 'Delete');
     }
-    $this->assertEqual(84, db_query("SELECT COUNT(*) FROM {node} WHERE type = 'article'")->fetchField());
+    $this->assertEqual(84, db_query("SELECT COUNT(*) FROM {node} WHERE type = 'post'")->fetchField());
     $this->cronRun();
-    $this->assertEqual(84, db_query("SELECT COUNT(*) FROM {node} WHERE type = 'article'")->fetchField());
+    $this->assertEqual(84, db_query("SELECT COUNT(*) FROM {node} WHERE type = 'post'")->fetchField());
   }
 
   /**

--- a/tests/feeds_tests.feeds.inc
+++ b/tests/feeds_tests.feeds.inc
@@ -1,9 +1,10 @@
 <?php
-
 /**
  * @file
  * Feeds hooks implementations.
  */
+
+include_once __DIR__ '/../plugins/FeedsPlugin.inc';
 
 /**
  * Implements hook_feeds_prevalidate().

--- a/tests/feeds_tests.feeds.inc
+++ b/tests/feeds_tests.feeds.inc
@@ -5,6 +5,7 @@
  */
 
 include_once __DIR__ '/../plugins/FeedsPlugin.inc';
+include_once __DIR__ '/../includes/FeedsConfigurable.inc';
 
 /**
  * Implements hook_feeds_prevalidate().

--- a/tests/feeds_tests.rules.inc
+++ b/tests/feeds_tests.rules.inc
@@ -32,7 +32,7 @@ function feeds_tests_rules_action_info() {
  * Rules action callback: creates a node.
  */
 function feeds_tests_create_node() {
-  $node = new stdClass();
+  $node = new Node();
   $node->title = 'Test node';
   $node->type = 'page';
   $node->status = 1;

--- a/tests/feeds_tokens.test
+++ b/tests/feeds_tokens.test
@@ -1,4 +1,9 @@
 <?php
+/**
+ * @file
+ */
+
+include_once __DIR__ . '/feeds.test';
 
 /**
  * Test cases for token replacement.

--- a/tests/http_request.test
+++ b/tests/http_request.test
@@ -5,7 +5,7 @@
  * Tests for http_request.inc.
  */
 
-include_once 'feeds.test';
+include_once __DIR__ . '/feeds.test';
 
 /**
  * Tests for the http library.


### PR DESCRIPTION
This <s>won't fix real test results</s>, but makes sure that: (there are some "drive-by fixes")

- The base test classes to extend are included
- No non-existent modules are attempted to enable
- No checks with non-existent content type "article"
- Entity creation of terms and nodes uses proper classes

Addresses #127 

These tests seem to work now:

- FeedsHTTPRequestTestCase
- FeedsFileFetcherTestCase
- FeedsMapperDateTestCase
- FeedsEnclosure
- FeedsMapperHookTestCase
- FeedsMapperConfigTestCase
- FeedsMapperUniqueTestCase
- FeedsUnitTestCase
- FeedsFetcherResult
- CommonSyndicationParserTestCase
- FeedsCSVParserTestCase
- FeedsContentTypeTest