### PR TITLE
Prevent PHP warning: Define code before it's passed into the cache item.

### DIFF
--- a/includes/FeedsHTTPCacheItem.inc
+++ b/includes/FeedsHTTPCacheItem.inc
@@ -25,6 +25,13 @@ class FeedsHTTPCacheItem {
   protected $cid;
 
   /**
+   * Code.
+   *
+   * @var string
+   */
+  protected $code;
+
+  /**
    * Headers of the response.
    *
    * @var array


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/feeds/issues/148